### PR TITLE
feat: update Playwright CI workflow to allow optional browser selecti…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,24 +9,49 @@ on:
         required: true
       browsername:
         description: 'Choose Browser'
+        # Expecting one of: chromium, chrome, chrome-beta, msedge, msedge-beta, msedge-dev, firefox, webkit
         default: 'chromium'
-        required: true
+        required: false
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-
 jobs:
-  build:
+  test:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
-
+    env:
+      ENV: dev
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Run a one-line script
-        run: echo Hello, World!
-
-      - name: Run multi-line script
-        run: 
-          echo "You requested running ${{ github.event.inputs.environmentname }} tests"
-          echo "Inside the ${{ github.event.inputs.browsername }} browser"
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      shell: bash
+      run: |
+        if [ -n "${{ github.event.inputs.browsername }}" ]; then
+          echo "Installing only ${{ github.event.inputs.browsername }} browser with dependencies."
+          npx playwright install --with-deps ${{ github.event.inputs.browsername }}
+        else
+          echo "Installing all browsers with dependencies as no specific browsername was provided."
+          npx playwright install --with-deps
+        fi
+    - name: Run Playwright tests
+      shell: bash
+      run: |
+        if [ -n "${{ github.event.inputs.browsername }}" ]; then
+          echo "Running Playwright tests with project: ${{ github.event.inputs.browsername }}"
+          npx playwright test --project=${{ github.event.inputs.browsername }}
+        else
+          echo "Running Playwright tests for all configured projects (or default)."
+          npx playwright test
+        fi
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,6 @@ on:
         # Expecting one of: chromium, chrome, chrome-beta, msedge, msedge-beta, msedge-dev, firefox, webkit
         default: 'chromium'
         required: false
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
 jobs:
   test:
     timeout-minutes: 15


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/main.yml` to improve the testing process by adding Playwright integration, enhancing browser selection flexibility, and refining the workflow configuration.

### Workflow enhancements:

* **Browser selection flexibility**: Added a description for the `browsername` input, listing supported browsers, and changed its `required` status from `true` to `false`. This allows users to optionally specify a browser for testing.
* **Job configuration**: Renamed the job from `build` to `test`, added a timeout of 15 minutes, and set the environment variable `ENV` to `dev`.

### Playwright integration:

* **Setup steps**: Added steps to install Node.js dependencies (`npm ci`) and Playwright browsers, with conditional logic to install either a specific browser or all browsers based on the `browsername` input.
* **Test execution**: Added steps to run Playwright tests, with conditional logic to execute tests for a specific browser project or all configured projects.
* **Artifact upload**: Added a step to upload Playwright test reports as workflow artifacts, with a retention period of 30 days.…on and enhance test execution steps